### PR TITLE
Update the metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,8 +5,8 @@
   "summary": "A module for monitoring for package updates",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-package_updates",
-  "project_page": "https://forge.puppetlabs.com/puppetlabs/package_updates",
-  "issues_url": "https://github.com/examplecorp/examplecorp-mymodule/issues",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-package_updates",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-package_updates/issues",
   "dependencies": [
   
   ],


### PR DESCRIPTION
Previous to this commit, the issues URL and project URL were incorrect
in the metadata.json file which caused incorrect links to be present on
the Forge page. This commmit uses the correct URLs