### PR TITLE
Add missing Puppet application

### DIFF
--- a/lib/puppet/application/package.rb
+++ b/lib/puppet/application/package.rb
@@ -1,0 +1,3 @@
+require 'puppet/application/face_base'
+class Puppet::Application::Package < Puppet::Application::FaceBase
+end


### PR DESCRIPTION
Previous to this commit, the lib/application/package.rb file was missing
which defines the Puppet package application.  Without this, the face
was inoperable.  This commit adds the missing application so the face
becomes functional.