### PR TITLE
Ensure facts.d directory exists

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,15 @@ class package_updates (
   $weekday  = undef,
 ) {
   if $::kernel != 'windows' {
+
+    # This is dumb but we must count on this directory existing
+    # and it may be managed somewhere else
+    exec { 'create facts.d':
+      command => 'mkdir -p /etc/puppetlabs/facter/facts.d/',
+      path    => '/bin:/usr/bin',
+      creates => '/etc/puppetlabs/facter/facts.d/',
+    }
+
     cron { 'package_updates':
       command  => 'puppet package updates --render-as json > /etc/puppetlabs/facter/facts.d/package_updates.json',
       minute   => $minute,


### PR DESCRIPTION
On default installs of the Puppet AIO agent, the
/etc/puppetlabs/facter/facts.d directory is not present. Users *may*
create this directory with Puppet or manually, but we cannot gaurantee
that it exists. This means the cron job cannot be gauranteed to work.

This commit creates an exec resource that ensures the directory exists.
An exec is used rather than a file resource because we cannot know if
the directory is managed elsewhere in the catalog. Since this is a
harmless operation, it's safe to use an exec in addition to
(potentially) a file resource