### PR TITLE
Package updates improvements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,12 @@ class package_updates (
   Variant[
     Integer[1,12],
     Array[Integer[1,12]],
+    Array[
+      Enum[
+        'january', 'february', 'march','april','may','june',
+        'july','august','september','october','november','december'
+      ]
+    ],
     Enum[
       'january', 'february', 'march','april','may','june',
       'july','august','september','october','november','december','all'
@@ -36,6 +42,11 @@ class package_updates (
   Variant[
     Integer[0,7],
     Array[Integer[0,7]],
+    Array[
+      Enum[
+        'sunday','monday','tuesday','wednesday',
+        'thursday','friday','saturday','sunday'
+      ]
     Enum[
       'sunday','monday','tuesday','wednesday',
       'thursday','friday','saturday','sunday','all'


### PR DESCRIPTION
This PR improves the class parameter values that can be passed to minute, hour, month, and weekday.  The minute parameter could not accept values greater than 9 and would default to a value of 0-9 which was not ideal.  The minute value can now be 0-59 and 'all' or any array of values between 0-9.  The hour parameter now accepts an array of Integers between 0 and 23.

The cron job command has been greatly improved.  Prior to this PR, the package_updates.json file would be emptied as the command began and would remain empty until the command completed, which can take up to a minute. If Facter is run while the cron job is executing, Facter would throw an error while attempting to parse the package_updates fact.  Now, the command outputs to a tmp file that's moved into place after the command is done executing.