### PR TITLE
Add name parameter to updates hash

### DIFF
--- a/lib/puppet/package.rb
+++ b/lib/puppet/package.rb
@@ -98,6 +98,7 @@ class Puppet::Package
 
       if latest != current
         package_updates[p.title] = {
+          'name'     => p.title,
           'current'  => current,
           'update'   => latest,
           'provider' => String(p[:provider])


### PR DESCRIPTION
This commit adds the 'name' key to the updates hash with the name of
the package as the value.  This makes querying the structure in PuppetDB
much easier