### PR TITLE
Add ability to execute some command before the cron scheduled command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ the cron job.
 * month - The month of the year. Default: undef
 * monthday - The day of the month to run the scan. Default: undef
 * weekday - The day of th week to run the scan. Default: undef
-* precommand - Array containing command to execute first. Default: undef
+* precommand - Array containing command to execute first. Default: Empty Array
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,36 @@ The module contains a single class: **package_updates**.  This class sets up a
 cron job to run the puppet face and caches the result in an external fact.  By
 default, the cron job runs every day at 3:00am.  You can change that with the
 available class parameters.
+The class will also allow to specify a list of command to execute before the
+cron command.  You can specify a proxy server and it's exclution as part of
+the cron job.
 
 * minute - The minute at which to run the scan. Default: undef
 * hour - The hour at which to run the scan. Default: 3
 * month - The month of the year. Default: undef
 * monthday - The day of the month to run the scan. Default: undef
 * weekday - The day of th week to run the scan. Default: undef
+* precommand - Array containing command to execute first. Default: undef
+
+**Example**
+
+You can define a $proxy_command Array and pass it to the class this way:
+
+    $proxy_command=["export http_proxy=${::proxy_server}",
+      "export https_proxy=${::proxy_server}",
+      "export no_proxy=${::no_proxy}"
+    ]
+    class {'::package_updates' :
+      precommand => $proxy_command,
+      schedule   => 'daily',
+      minute     => 0,
+      hour       => 3,
+      month      => 'all',
+      monthday   => 'all',
+      weekday    => 'all',
+    }
+
+Proxy defined in this way should work, with the correct exclusion, with all the package provider.
 
 #### Using the Puppet Command Line Interface
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,5 @@
 class package_updates (
+  Array[String] $precommand= [],
 
   Enum['daily','weekly','monthly','once'] $schedule = 'daily',
 
@@ -97,12 +98,17 @@ class package_updates (
     $facts_d_directory = '/opt/puppetlabs/facter/facts.d'
     $tmp_path          = '/tmp/package_updates.json'
 
+    if $precommand != [] {
+      $precmd="${join($precommand,';')};"
+    } else {
+      $precmd=''
+    }
     # The `package updates` command takes a long time to run. Since the command is using shell
     # redirection, the target file is truncated prior to the `package updates` command being run.
     # Thus Facter will throw an error while looking up the package_updates fact if Facter is run
     # while the cron job is executing. So instead we'll output to a tmp file and mv the
     # file into place when the `package_updates` command is done executing.
-    $command = "${puppet_path} ${updates_subcommand} > ${tmp_path} && mv -f ${tmp_path} ${facts_d_directory}/"
+    $command = "${precmd}${puppet_path} ${updates_subcommand} > ${tmp_path} && mv -f ${tmp_path} ${facts_d_directory}/"
 
     cron { 'package_updates':
       command  => $command,


### PR DESCRIPTION
Related to issue #20 
Add an Array $precommand containing commands to execute before executing the cron command.
With those pre-command is possible to setup the proxy this way:
```
  $proxy_command=["export http_proxy=${::proxy_server}",
    "export https_proxy=${::proxy_server}",
    "export no_proxy=${::no_proxy}"
  ]
  class {'::package_updates' :
    precommand => $proxy_command,
    schedule   => 'daily',
    minute     => 0,
    hour       => 3,
    month      => 'all',
    monthday   => 'all',
    weekday    => 'all',
  }
```