### PR TITLE
Return rather than puts the json representation

### DIFF
--- a/lib/puppet/face/package.rb
+++ b/lib/puppet/face/package.rb
@@ -47,7 +47,7 @@ Puppet::Indirector::Face.define(:package, '0.0.1') do
     end
 
     when_rendering :json do |package_updates|
-      package_updates.to_json
+      package_updates
     end
   end
 

--- a/lib/puppet/face/package.rb
+++ b/lib/puppet/face/package.rb
@@ -47,7 +47,7 @@ Puppet::Indirector::Face.define(:package, '0.0.1') do
     end
 
     when_rendering :json do |package_updates|
-      puts package_updates.to_json
+      package_updates.to_json
     end
   end
 


### PR DESCRIPTION
Return rather than puts the json representation, to avoid spurious 'null' in output.